### PR TITLE
Sphinx docs links and dependencies update after MD reformat.

### DIFF
--- a/docs/advanced/index.rst
+++ b/docs/advanced/index.rst
@@ -11,7 +11,7 @@ Various advanced topics regarding cookiecutter usage.
    hooks
    user_config
    calling_from_python
-   injecting_content
+   injecting_context
    suppressing_prompts
    templates_in_context
    copy_without_render

--- a/docs/authors.rst
+++ b/docs/authors.rst
@@ -1,1 +1,1 @@
-.. include:: ../AUTHORS.rst
+.. mdinclude:: ../AUTHORS.md

--- a/docs/case_studies.rst
+++ b/docs/case_studies.rst
@@ -1,1 +1,1 @@
-.. include:: ../case_studies.rst
+.. mdinclude:: ../case_studies.md

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -63,13 +63,13 @@ import cookiecutter
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.doctest', 'sphinx.ext.intersphinx',
               'sphinx.ext.todo', 'sphinx.ext.coverage', 'sphinx.ext.imgmath',
-              'sphinx.ext.ifconfig', 'sphinx.ext.viewcode', 'docs.ccext']
+              'sphinx.ext.ifconfig', 'sphinx.ext.viewcode', 'docs.ccext', 'm2r']
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = ['.rst', '.md']
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'

--- a/docs/contributor_testing.rst
+++ b/docs/contributor_testing.rst
@@ -34,3 +34,5 @@ is::
 
 Will run py.test with the python2.7, python3.4 and pypy interpreters, for
 example.
+
+.. _`pytest usage docs`: http://pytest.org/en/latest/contents.html

--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,1 +1,1 @@
-.. include:: ../HISTORY.rst
+.. mdinclude:: ../HISTORY.md

--- a/docs/readme.rst
+++ b/docs/readme.rst
@@ -1,3 +1,3 @@
 .. _readme:
 
-.. include:: ../README.rst
+.. mdinclude:: ../README.md

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
 watchdog==0.8.3
-sphinx-rtd-theme==0.1.9
+sphinx-rtd-theme==0.4.3
+m2r==0.2.1

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ if sys.argv[-1] == 'tag':
     os.system("git push --tags")
     sys.exit()
 
-with io.open('README.rst', 'r', encoding='utf-8') as readme_file:
+with io.open('README.md', 'r', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
 requirements = [
@@ -45,6 +45,7 @@ setup(
                  'templates, e.g. creating a Python package project from a '
                  'Python package project template.'),
     long_description=readme,
+    long_description_content_type='text/markdown',
     author='Audrey Roy',
     author_email='audreyr@gmail.com',
     url='https://github.com/audreyr/cookiecutter',


### PR DESCRIPTION
After you drop RST files in main directory Sphinx doc will be broken. 
This fix installs dependencies and change links in files, so Sphinx docs will work again.